### PR TITLE
Configure compression

### DIFF
--- a/config/nginx/sites-template/default
+++ b/config/nginx/sites-template/default
@@ -38,6 +38,14 @@ server {
         fastcgi_param SERVER_NAME $host;
     }
 
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/html text/css
+        application/javascript text/javascript application/json
+        text/xml application/xml application/xml+rss;
+
     error_log /dev/stdout;
     access_log /dev/stdout json buffer=64k flush=$PHP_HTTP_LOG_FLUSH;
 }


### PR DESCRIPTION
Enable gzip for plain, js, css, html and xml with compression level 6.